### PR TITLE
Handling resource file name in import

### DIFF
--- a/LangTools/src/com/gdubina/tool/langutil/Tool.java
+++ b/LangTools/src/com/gdubina/tool/langutil/Tool.java
@@ -17,7 +17,11 @@ public class Tool {
 		}
 		
 		if("-i".equals(args[0])){
-			ToolImport.run(args[1]);
+			if (args.length > 2) {			
+				ToolImport.run(args[1], args[2]);				
+			} else {
+				ToolImport.run(args[1]);				
+			}
 		}else if("-e".equals(args[0])){
 			if (args.length > 2 && "-f".equals(args[2])) {
 				ToolExport.run(args[1], args.length > 4 ? args[4] : null, args[3]);

--- a/LangTools/src/com/gdubina/tool/langutil/ToolExport.java
+++ b/LangTools/src/com/gdubina/tool/langutil/ToolExport.java
@@ -50,7 +50,7 @@ public class ToolExport {
 			System.out.println("Project dir is missed");
 			return;
 		}
-		run(null, args[0], args.length > 1 ? args[1] : null, null);
+		run(null, args[0], args.length > 1 ? args[1] : null, args.length > 2 ? args[2] : null);
 	}
 	
 	public static void run(String projectDir, String outputFile) throws SAXException, IOException, ParserConfigurationException {

--- a/LangTools/src/com/gdubina/tool/langutil/ToolImport.java
+++ b/LangTools/src/com/gdubina/tool/langutil/ToolImport.java
@@ -45,6 +45,10 @@ public class ToolImport {
 	}
 	
 	public static void run(String input) throws FileNotFoundException, IOException, ParserConfigurationException, TransformerException{
+		run(input, null);
+	}
+	
+	public static void run(String input, String stringsFile) throws FileNotFoundException, IOException, ParserConfigurationException, TransformerException{
 		if(input == null || "".equals(input)){
 			System.out.println("File name is missed");
 			return;
@@ -56,10 +60,10 @@ public class ToolImport {
 		ToolImport tool = new ToolImport(null);
 		tool.outResDir = new File("out/" + sheet.getSheetName()+ "/res");
 		tool.outResDir.mkdirs();
-		tool.parse(sheet);		
+		tool.parse(sheet, stringsFile);		
 	}
 	
-	public static void run(PrintStream out, String projectDir, String input) throws FileNotFoundException, IOException, ParserConfigurationException, TransformerException{
+	public static void run(PrintStream out, String projectDir, String input, String stringsFile) throws FileNotFoundException, IOException, ParserConfigurationException, TransformerException{
 		ToolImport tool = new ToolImport(out);
 		if(input == null || "".equals(input)){
 			tool.out.println("File name is missed");
@@ -72,22 +76,22 @@ public class ToolImport {
 
 		tool.outResDir = new File(projectDir, "/res");
 		//tool.outResDir.mkdirs();
-		tool.parse(sheet);		
+		tool.parse(sheet, stringsFile);		
 	}
 
-	private void parse(HSSFSheet sheet) throws IOException, TransformerException {
+	private void parse(HSSFSheet sheet, String stringsFile) throws IOException, TransformerException {
 		Row row = sheet.getRow(0);
 		Iterator<Cell> cells = row.cellIterator();
 		cells.next();// ignore key
 		int i = 1;
 		while (cells.hasNext()) {
 			String lang = cells.next().toString();
-			generateLang(sheet, lang, i);
+			generateLang(sheet, lang, i, stringsFile);
 			i++;
 		}
 	}
 
-	private void generateLang(HSSFSheet sheet, String lang, int column) throws IOException, TransformerException {
+	private void generateLang(HSSFSheet sheet, String lang, int column, String stringsFile) throws IOException, TransformerException {
 		
 		Document dom = builder.newDocument();
 		Element root = dom.createElement("resources");
@@ -181,14 +185,14 @@ public class ToolImport {
 
 		}
 		
-		save(dom, lang);
+		save(dom, lang, stringsFile);
 	}
 	
 	private static void addEmptyKeyValue(Document dom, Element root, String key){
 		root.appendChild(dom.createComment(String.format(" TODO: string name=\"%s\" ", key)));
 	} 
 
-	private void save(Document doc, String lang) throws TransformerException {
+	private void save(Document doc, String lang, String fileName) throws TransformerException {
 		File dir;
 		if("default".equals(lang) || lang == null || "".equals(lang)){
 			dir = new File(outResDir, "values");
@@ -204,7 +208,10 @@ public class ToolImport {
 		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 		
 		DOMSource source = new DOMSource(doc);
-		StreamResult result = new StreamResult(new File(dir, "strings.xml"));
+		if (fileName == null || fileName.length() == 0) {
+			fileName = "strings.xml";
+		}
+		StreamResult result = new StreamResult(new File(dir, fileName));
 
 		transformer.transform(source, result);
 	}

--- a/LangTools/src/com/gdubina/tool/langutil/ToolImport.java
+++ b/LangTools/src/com/gdubina/tool/langutil/ToolImport.java
@@ -53,6 +53,11 @@ public class ToolImport {
 			System.out.println("File name is missed");
 			return;
 		}
+
+		if (stringsFile == null || stringsFile.length() == 0) {
+			stringsFile = "strings.xml";
+		}
+
 		HSSFWorkbook wb = new HSSFWorkbook(new FileInputStream(new File(input)));
 		HSSFSheet sheet = wb.getSheetAt(0);
 		
@@ -208,9 +213,6 @@ public class ToolImport {
 		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 		
 		DOMSource source = new DOMSource(doc);
-		if (fileName == null || fileName.length() == 0) {
-			fileName = "strings.xml";
-		}
 		StreamResult result = new StreamResult(new File(dir, fileName));
 
 		transformer.transform(source, result);


### PR DESCRIPTION
Until now, when importing the result was always written in the corresponding "strings.xml" files. 
With these changes you can specify a different file name.
Example:
java -jar LangTool.jar -i datafile.xls extra-strings.xml
