### PR TITLE
Update ToolExport.java

### DIFF
--- a/LangTools/src/com/gdubina/tool/langutil/ToolExport.java
+++ b/LangTools/src/com/gdubina/tool/langutil/ToolExport.java
@@ -89,10 +89,6 @@ public class ToolExport {
 				keysIndex = exportDefLang(dir);
 			}
 		}
-		if (keysIndex == null) {
-			System.out.println("res/values/ folder doesn't exists");
-			return;
-		}
 		for(File dir : res.listFiles()){
 			if(!dir.isDirectory() || !dir.getName().startsWith(DIR_VALUES)){
 				continue;


### PR DESCRIPTION
Fixed issue #6 removing the `if` that cause the exit from `for` loop, when exporting from directories with different from the default (`values`).